### PR TITLE
remove hardcoded version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ COPY repostats.py /
 COPY Pipfile /
 COPY Pipfile.lock /
 
-# https://github.com/pypa/pipenv/issues/4273
-RUN pip install 'pipenv==2018.11.26'
+RUN pip install pipenv
 RUN pipenv install --deploy --ignore-pipfile
 
 ENTRYPOINT ["pipenv", "run", "python", "/main.py"]


### PR DESCRIPTION
Just a small thing. I wonder if the version is needed considering the bug has been fixed? Seems to work on my fork:
![image](https://user-images.githubusercontent.com/21298559/159082751-8ee35d19-1c7f-410b-8b5a-973606e740b7.png)

Might still be good practice to fix it to a particular version...